### PR TITLE
docs: document AuthenticationError exception in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ WebSocket client for real-time voice conversation.
 The library provides several exception classes for error handling:
 
 - `SesameAIError` - Base exception class
-- `InvalidTokenError` - Invalid token errors
+- `AuthenticationError` - Base class for authentication failures
+- `InvalidTokenError` - Invalid token errors (subclass of `AuthenticationError`)
 - `APIError` - API errors with code and message
 - `NetworkError` - Network communication errors
 


### PR DESCRIPTION
## Summary

README review pass for `sesame_ai`. The README is accurate and thorough — all three referenced examples (`voice_chat.py`, `bee8b_slogan.py`, `gradio_client_usage.py`) exist, and the documented `SesameAI`, `TokenManager`, and `SesameWebSocket` APIs match the source. One small gap found.

## Changes

- Added `AuthenticationError` to the Error Handling section. It is exported from the package (`sesame_ai/__init__.py`) and is the parent class of `InvalidTokenError`, but was previously undocumented. Also noted the subclass relationship.

## Verification

- `sesame_ai/__init__.py` exports: `SesameAI`, `SesameWebSocket`, `SesameAIError`, `AuthenticationError`, `APIError`, `InvalidTokenError`, `NetworkError`, plus models.
- `sesame_ai/exceptions.py`: `class InvalidTokenError(AuthenticationError)` confirms the hierarchy.
- All `examples/` files referenced in the README are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwF9tdwBDxC3wqWngk8Kzi)_